### PR TITLE
Add quartz yaml and fix scheduler startup script

### DIFF
--- a/dfanalyzer/dask/conf/quartz.yaml
+++ b/dfanalyzer/dask/conf/quartz.yaml
@@ -1,0 +1,20 @@
+config:
+  script_dir: ${DFTRACER_APP}/dfanalyzer/dask/scripts
+  conf_dir: ${DFTRACER_APP}/dfanalyzer/dask/conf
+  run_dir: ${DFTRACER_APP}/dfanalyzer/dask/run_dir
+  log_dir: ${DFTRACER_APP}/dfanalyzer/dask/logs
+job:
+  num_nodes: 4
+  wall_time_min: 60
+  env_id: SLURM_JOB_ID
+scheduler:
+  cmd: srun -N ${DFTRACER_JOB_NUM_NODES} -t ${DFTRACER_JOB_WALL_TIME_MIN}
+  port: 12005
+  kill: scancel ${SLURM_JOB_ID}
+worker:
+  ppn: 16
+  cmd: srun -N ${DFTRACER_JOB_NUM_NODES} --ntasks-per-node=${DFTRACER_WORKER_PPN}
+  per_core: 1
+  threads: 1
+  local_dir: /dev/shm/dask-workspace
+  kill: scancel ${SLURM_JOB_ID}

--- a/dfanalyzer/dask/scripts/start_dask_distributed.sh
+++ b/dfanalyzer/dask/scripts/start_dask_distributed.sh
@@ -12,6 +12,9 @@ case $hostname in
   *"ruby"*)
     DFTRACER_DASK_CONF_NAME=${DFTRACER_APP}/dfanalyzer/dask/conf/ruby.yaml
     ;;
+  "quartz"*)
+    DFTRACER_DASK_CONF_NAME=${DFTRACER_APP}/dfanalyzer/dask/conf/quartz.yaml
+    ;;
 esac
 
 if [[ "$DFTRACER_DASK_CONF_NAME" == "UNSET" ]]; then
@@ -28,8 +31,26 @@ eval $(parse_yaml $DFTRACER_DASK_CONF_NAME DFTRACER_)
 
 source ${DFTRACER_ENV}/bin/activate
 
+rm -rf ${DFTRACER_CONFIG_RUN_DIR}/scheduler_${USER}.json
+
 dask scheduler --scheduler-file ${DFTRACER_CONFIG_RUN_DIR}/scheduler_${USER}.json --port ${DFTRACER_SCHEDULER_PORT} > ${DFTRACER_CONFIG_LOG_DIR}/scheduler_${USER}.log 2>&1 &
 scheduler_pid=$!
 echo $scheduler_pid > ${DFTRACER_CONFIG_RUN_DIR}/scheduler_${USER}.pid
+
+file=${DFTRACER_CONFIG_RUN_DIR}/scheduler_${USER}.json
+timeout=30  # seconds to wait for timeout
+SECONDS=0   # initialize bash's builtin counter 
+
+until [ -s "$file" ] || (( SECONDS >= timeout )); do sleep 1; done
+
+
+if test -f $file;
+then
+   echo "Scheduler with $scheduler_pid is running"
+   # Do something knowing the pid exists, i.e. the process with $PID is running
+else
+   echo "Scheduler with $scheduler_pid failed. Check the ${DFTRACER_CONFIG_LOG_DIR}/scheduler_${USER}.log file"
+   exit 1
+fi
 
 ${DFTRACER_SCHEDULER_CMD} ${DFTRACER_CONFIG_SCRIPT_DIR}/start_dask_worker.sh ${DFTRACER_DASK_CONF_NAME}


### PR DESCRIPTION
In this PR we add the following two things.

1. Quartz yaml:  A configuration to run the Dask distributed scripts on the Quartz cluster at Livermore Computing.
2. Fix for error checking for the Dask scheduler. DFAnalyzer can use the Dask cluster to perform distributed analysis. In the `start_dask_distributed.sh`, we added a condition to check the scheduler's successful execution. The scheduler outputs a JSON file that can be checked at runtime for creation. If it is not created, we add a message to the users to check for errors.