### PR TITLE
Enhance: Report warning when the summary reports overall io_time more than total time

### DIFF
--- a/dfanalyzer/main.py
+++ b/dfanalyzer/main.py
@@ -456,6 +456,12 @@ class DFAnalyzer:
             grouped_df = self.events.groupby(["trange", "pid", "tid"]) \
                             .agg({"compute_time": sum, "io_time": sum, "app_io_time": sum}) \
                             .groupby(["trange"]).max()
+            # check if the max io_time > time_granularity
+            max_io_time = grouped_df.max().compute()['io_time']
+            if max_io_time > self.conf.time_granularity:
+                # throw a warning, running with large granuality
+                logging.warn(f"The max io_time {max_io_time} exceeds the time_granularity {self.conf.time_granularity}. " \
+                             f"Please adjust the time_granularity to {int(2 * max_io_time /1e6)}e6 and rerun the analyzer.")
             grouped_df["io_time"] = grouped_df["io_time"].fillna(0)
             grouped_df["compute_time"] = grouped_df["compute_time"].fillna(0)
             grouped_df["app_io_time"] = grouped_df["app_io_time"].fillna(0)


### PR DESCRIPTION
This PR addresses #158 by enhancing the summary function by adding a warning message and a potential fix when overall io_time more than total time.