### PR TITLE
Bugfix: fixed hash to be integers

### DIFF
--- a/include/dftracer/core/constants.h
+++ b/include/dftracer/core/constants.h
@@ -29,5 +29,6 @@ static const int EVENT_TYPE_SIZE = 128;
 static const unsigned int DFT_PATH_MAX = 1024 * 4;
 static const char SEPARATOR = ';';
 static const int HASH_OUTPUT = 16;
+#define NO_HASH_DEFAULT 0
 
 #endif  // DFTRACER_CONSTANTS_H

--- a/include/dftracer/core/typedef.h
+++ b/include/dftracer/core/typedef.h
@@ -9,4 +9,5 @@ typedef unsigned long int ThreadID;
 typedef unsigned long int ProcessID;
 typedef char* EventNameType;
 typedef const char* ConstEventNameType;
+typedef unsigned long long HashType;
 #endif  // DFTRACER_TYPEDEF_H

--- a/src/dftracer/brahma/posix.h
+++ b/src/dftracer/brahma/posix.h
@@ -26,7 +26,7 @@ class POSIXDFTracer : public POSIX {
  private:
   static bool stop_trace;
   static std::shared_ptr<POSIXDFTracer> instance;
-  static const int MAX_FD = 1024 * 1024;
+  static const int MAX_FD = 1024;
   HashType tracked_fd[MAX_FD];
   std::shared_ptr<DFTLogger> logger;
   bool trace_all_files;

--- a/src/dftracer/brahma/posix.h
+++ b/src/dftracer/brahma/posix.h
@@ -6,7 +6,9 @@
 #define DFTRACER_POSIX_H
 
 #include <brahma/brahma.h>
+#include <dftracer/core/constants.h>
 #include <dftracer/core/logging.h>
+#include <dftracer/core/typedef.h>
 #include <dftracer/df_logger.h>
 #include <dftracer/utils/md5.h>
 #include <dftracer/utils/utils.h>
@@ -24,25 +26,25 @@ class POSIXDFTracer : public POSIX {
  private:
   static bool stop_trace;
   static std::shared_ptr<POSIXDFTracer> instance;
-  static const int MAX_FD = 1024;
-  std::string tracked_fd[MAX_FD];
+  static const int MAX_FD = 1024 * 1024;
+  HashType tracked_fd[MAX_FD];
   std::shared_ptr<DFTLogger> logger;
   bool trace_all_files;
 
-  inline std::string is_traced(int fd, const char *func) {
-    if (fd < 0) return std::string();
-    std::string trace = tracked_fd[fd % MAX_FD];
-    if (trace.empty()) {
+  inline HashType is_traced(int fd, const char *func) {
+    if (fd < 0) return NO_HASH_DEFAULT;
+    HashType trace = tracked_fd[fd % MAX_FD];
+    if (trace == NO_HASH_DEFAULT) {
       DFTRACER_LOG_DEBUG(
           "Calling POSIXDFTracer.is_traced for %s and"
           " fd %d trace %d",
-          func, fd, !trace.empty());
+          func, fd, trace != NO_HASH_DEFAULT);
     }
     return trace;
   }
 
-  inline std::string is_traced(const char *filename, const char *func) {
-    if (stop_trace) return std::string();
+  inline HashType is_traced(const char *filename, const char *func) {
+    if (stop_trace) return NO_HASH_DEFAULT;
     if (trace_all_files) {
       return logger->hash_and_store(filename, METADATA_NAME_FILE_HASH);
     } else {
@@ -57,7 +59,7 @@ class POSIXDFTracer : public POSIX {
     }
   }
 
-  inline void trace(int fd, std::string hash) {
+  inline void trace(int fd, HashType hash) {
     DFTRACER_LOG_DEBUG("Calling POSIXDFTracer.trace for %d and %d", fd, hash);
     if (fd == -1) return;
     tracked_fd[fd % MAX_FD] = hash;
@@ -66,13 +68,13 @@ class POSIXDFTracer : public POSIX {
   inline void remove_trace(int fd) {
     DFTRACER_LOG_DEBUG("Calling POSIXDFTracer.remove_trace for %d", fd);
     if (fd == -1) return;
-    tracked_fd[fd % MAX_FD] = std::string();
+    tracked_fd[fd % MAX_FD] = NO_HASH_DEFAULT;
   }
 
  public:
   POSIXDFTracer(bool trace_all) : POSIX(), trace_all_files(trace_all) {
     DFTRACER_LOG_DEBUG("POSIX class intercepted", "");
-    for (int i = 0; i < MAX_FD; ++i) tracked_fd[i] = std::string();
+    for (int i = 0; i < MAX_FD; ++i) tracked_fd[i] = NO_HASH_DEFAULT;
     logger = DFT_LOGGER_INIT();
   }
   void finalize() {

--- a/src/dftracer/brahma/stdio.h
+++ b/src/dftracer/brahma/stdio.h
@@ -7,6 +7,8 @@
 
 #include <brahma/brahma.h>
 #include <dftracer/core/logging.h>
+#include <dftracer/core/typedef.h>
+#include <dftracer/core/constants.h>
 #include <dftracer/df_logger.h>
 #include <dftracer/utils/utils.h>
 #include <fcntl.h>
@@ -22,25 +24,25 @@ class STDIODFTracer : public STDIO {
  private:
   static bool stop_trace;
   static std::shared_ptr<STDIODFTracer> instance;
-  std::unordered_map<FILE *, std::string> tracked_fh;
+  std::unordered_map<FILE *, HashType> tracked_fh;
   std::shared_ptr<DFTLogger> logger;
   bool trace_all_files;
 
-  inline std::string is_traced(FILE *fh, const char *func) {
+  inline HashType is_traced(FILE *fh, const char *func) {
     DFTRACER_LOG_DEBUG("Calling STDIODFTracer.is_traced for %s", func);
-    if (stop_trace) return std::string();
-    if (fh == NULL) return std::string();
+    if (stop_trace) return NO_HASH_DEFAULT;
+    if (fh == NULL) return NO_HASH_DEFAULT;
     auto iter = tracked_fh.find(fh);
     if (iter != tracked_fh.end()) {
       return iter->second;
     }
-    return std::string();
+    return NO_HASH_DEFAULT;
   }
 
-  inline std::string is_traced(const char *filename, const char *func) {
+  inline HashType is_traced(const char *filename, const char *func) {
     DFTRACER_LOG_DEBUG("Calling STDIODFTracer.is_traced with filename for %s",
                        func);
-    if (stop_trace) return std::string();
+    if (stop_trace) return NO_HASH_DEFAULT;
     if (trace_all_files)
       return logger->hash_and_store(filename, METADATA_NAME_FILE_HASH);
     else {
@@ -49,7 +51,7 @@ class STDIODFTracer : public STDIO {
     }
   }
 
-  inline void trace(FILE *fh, std::string hash) {
+  inline void trace(FILE *fh, HashType hash) {
     DFTRACER_LOG_DEBUG("Calling STDIODFTracer.trace with hash %d", hash);
     tracked_fh.insert_or_assign(fh, hash);
   }

--- a/src/dftracer/df_logger.h
+++ b/src/dftracer/df_logger.h
@@ -109,10 +109,9 @@ class DFTLogger {
   inline HashType get_hash(char *name) {
     uint8_t result[HASH_OUTPUT];
     md5String(name, result);
-    std::string hash_str;
-    hash_str.reserve(HASH_OUTPUT + 1);
+    char hash_str[HASH_OUTPUT + 1];
     for (int i = 0; i < HASH_OUTPUT; ++i) {
-      sprintf(hash_str.data() + i, "%02x", result[i]);
+      sprintf(hash_str + i, "%02x", result[i]);
     }
     hash_str[HASH_OUTPUT] = '\0';
     HashType hash = std::stoull(hash_str, nullptr, 16);
@@ -425,19 +424,19 @@ class DFTLogger {
     DFT_LOGGER_UPDATE(value##_hash);                                  \
   }
 
-#define DFT_LOGGER_START(entity)                                    \
-  DFTRACER_LOG_DEBUG("Calling function %s", __FUNCTION__);          \
-  HashType fhash = is_traced(entity, __FUNCTION__);                 \
-  bool trace = fhash != NO_HASH_DEFAULT;                            \
-  TimeResolution start_time = 0;                                    \
-  std::unordered_map<std::string, std::any> *metadata = nullptr;    \
-  if (trace) {                                                      \
-    if (this->logger->include_metadata) {                           \
-      metadata = new std::unordered_map<std::string, std::any>();   \
-      DFT_LOGGER_UPDATE(fhash);                                     \
-    }                                                               \
-    this->logger->enter_event();                                    \
-    start_time = this->logger->get_time();                          \
+#define DFT_LOGGER_START(entity)                                  \
+  DFTRACER_LOG_DEBUG("Calling function %s", __FUNCTION__);        \
+  HashType fhash = is_traced(entity, __FUNCTION__);               \
+  bool trace = fhash != NO_HASH_DEFAULT;                          \
+  TimeResolution start_time = 0;                                  \
+  std::unordered_map<std::string, std::any> *metadata = nullptr;  \
+  if (trace) {                                                    \
+    if (this->logger->include_metadata) {                         \
+      metadata = new std::unordered_map<std::string, std::any>(); \
+      DFT_LOGGER_UPDATE(fhash);                                   \
+    }                                                             \
+    this->logger->enter_event();                                  \
+    start_time = this->logger->get_time();                        \
   }
 #define DFT_LOGGER_START_ALWAYS()                                 \
   DFTRACER_LOG_DEBUG("Calling function %s", __FUNCTION__);        \

--- a/src/dftracer/writer/chrome_writer.cpp
+++ b/src/dftracer/writer/chrome_writer.cpp
@@ -22,7 +22,7 @@ template <>
 bool dftracer::Singleton<dftracer::ChromeWriter>::stop_creating_instances =
     false;
 void dftracer::ChromeWriter::initialize(char *filename, bool throw_error,
-                                        const char *hostname_hash) {
+                                        HashType hostname_hash) {
   this->hostname_hash = hostname_hash;
   this->throw_error = throw_error;
   this->filename = filename;
@@ -214,10 +214,9 @@ void dftracer::ChromeWriter::convert_json(
       previous_index = current_index;
       auto written_size = sprintf(
           buffer.data() + current_index,
-          R"(%s{"id":%d,"name":"%s","cat":"%s","pid":%lu,"tid":%lu,"ts":%llu,"dur":%llu,"ph":"X","args":{"hhash":"%s"%s}})",
+          R"(%s{"id":%d,"name":"%s","cat":"%s","pid":%lu,"tid":%lu,"ts":%llu,"dur":%llu,"ph":"X","args":{"hhash":%llu%s}})",
           is_first_char, index, event_name, category, process_id, thread_id,
-          start_time, duration, this->hostname_hash.c_str(),
-          all_stream.str().c_str());
+          start_time, duration, this->hostname_hash, all_stream.str().c_str());
       current_index += written_size;
       buffer[current_index] = '\n';
       current_index++;
@@ -256,15 +255,15 @@ void dftracer::ChromeWriter::convert_json_metadata(
     if (is_string) {
       written_size = sprintf(
           buffer.data() + current_index,
-          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":"%s","name":"%s","value":"%s"}})",
-          is_first_char, index, ph, process_id, thread_id,
-          this->hostname_hash.c_str(), name, value);
+          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":%llu,"name":"%s","value":"%s"}})",
+          is_first_char, index, ph, process_id, thread_id, this->hostname_hash,
+          name, value);
     } else {
       written_size = sprintf(
           buffer.data() + current_index,
-          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":"%s","name":"%s","value":%s}})",
-          is_first_char, index, ph, process_id, thread_id,
-          this->hostname_hash.c_str(), name, value);
+          R"(%s{"id":%d,"name":"%s","cat":"dftracer","pid":%lu,"tid":%lu,"ph":"M","args":{"hhash":%llu,"name":"%s","value":%s}})",
+          is_first_char, index, ph, process_id, thread_id, this->hostname_hash,
+          name, value);
     }
     current_index += written_size;
     buffer[current_index] = '\n';

--- a/src/dftracer/writer/chrome_writer.cpp
+++ b/src/dftracer/writer/chrome_writer.cpp
@@ -185,6 +185,11 @@ void dftracer::ChromeWriter::convert_json(
                     << "\":" << std::any_cast<uint16_t>(item.second) << "";
         if (i < meta_size - 1) meta_stream << ",";
 
+      } else if (item.second.type() == typeid(HashType)) {
+        meta_stream << "\"" << item.first
+                    << "\":" << std::any_cast<HashType>(item.second) << "";
+        if (i < meta_size - 1) meta_stream << ",";
+
       } else if (item.second.type() == typeid(long)) {
         meta_stream << "\"" << item.first
                     << "\":" << std::any_cast<long>(item.second) << "";

--- a/src/dftracer/writer/chrome_writer.h
+++ b/src/dftracer/writer/chrome_writer.h
@@ -36,7 +36,7 @@ class ChromeWriter {
   bool enable_core_affinity;
 
   FILE *fh;
-  std::string hostname_hash;
+  HashType hostname_hash;
   static const int MAX_LINE_SIZE = 16 * 1024L;
   size_t write_buffer_size;
 
@@ -100,7 +100,7 @@ class ChromeWriter {
     }
   }
   ~ChromeWriter() { DFTRACER_LOG_DEBUG("Destructing ChromeWriter", ""); }
-  void initialize(char *filename, bool throw_error, const char *hostname_hash);
+  void initialize(char *filename, bool throw_error, HashType hostname_hash);
 
   void log(int index, ConstEventNameType event_name,
            ConstEventNameType category, TimeResolution start_time,


### PR DESCRIPTION
Strings for hashes are inefficient to transfer and become out of scope. So we now convert them into ull. 